### PR TITLE
Add initial command-line interface

### DIFF
--- a/src/Abstracts/IActionGenerator.cs
+++ b/src/Abstracts/IActionGenerator.cs
@@ -5,9 +5,10 @@ namespace Microsoft.NugetNinja;
 
 public interface IActionGenerator
 {
-    public string GetHelp();
+    public string[] CommandAliases { get; }
 
-    public string GetCommandAlias();
+    public string CommandDescription { get; }
 
     public IEnumerable<IAction> Analyze(Model context);
+
 }

--- a/src/Entry.cs
+++ b/src/Entry.cs
@@ -32,7 +32,7 @@ public class Entry
 
         var pathOption = new Option<string>(
             aliases: new[] { "--path", "-p" },
-            description: "Path of the project to be scanned.")
+            description: "Path of the project to be scanned")
         {
             IsRequired = true
         };

--- a/src/Entry.cs
+++ b/src/Entry.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
+using System.CommandLine;
 
 namespace Microsoft.NugetNinja;
 
@@ -21,28 +22,52 @@ public class Entry
         this.logger = logger;
     }
 
-    public async Task RunAsync(string[] args)
+    public async Task<int> RunAsync(string[] args)
     {
-        logger.LogInformation("Starting NugetNinja...");
+        var rootCommand = new RootCommand(@"🥷 Nuget Ninja, a tool for detecting dependencies of .NET projects.");
 
-        if (args.Length < 1)
+        var dryRunOption = new Option<bool>(
+            aliases: new[] { "--dry-run", "-d" },
+            description: "Preview changes without actually making them");
+
+        var pathOption = new Option<string>(
+            aliases: new[] { "--path", "-p" },
+            description: "Path of the project to be scanned.")
         {
-            logger.LogWarning("Usage: [Working path]");
-            return;
-        }
+            IsRequired = true
+        };
 
-        var workingPath = args[0];
-        var model = await extractor.Parse(workingPath);
+        rootCommand.AddGlobalOption(dryRunOption);
+        rootCommand.AddGlobalOption(pathOption);
 
-        foreach(var generator in this.generators)
+        foreach (var generator in this.generators)
         {
-            var actions = generator.Analyze(model);
-            foreach (var action in actions)
+            var subCommand = new Command(generator.CommandAliases.First(), generator.CommandDescription);
+            foreach (var alias in generator.CommandAliases.Skip(1))
             {
-                logger.LogWarning(action.BuildMessage());
+                subCommand.AddAlias(alias);
             }
+
+            subCommand.SetHandler(async (path, isDryRun) =>
+                {
+                    logger.LogTrace($"Args: path = {path}, isDryRun = {isDryRun}");
+
+                    var model = await extractor.Parse(path);
+                    var actions = generator.Analyze(model);
+                    foreach (var action in actions)
+                    {
+                        action.BuildMessage();
+                        if (!isDryRun)
+                        {
+                            action.TakeAction();
+                        }
+                    }
+                },
+                pathOption, dryRunOption);
+
+            rootCommand.Add(subCommand);
         }
 
-        logger.LogTrace("Stopping NugetNinja...");
+        return await rootCommand.InvokeAsync(args);
     }
 }

--- a/src/Generators/UselessPackageReferenceDetector.cs
+++ b/src/Generators/UselessPackageReferenceDetector.cs
@@ -7,6 +7,9 @@ public class UselessPackageReferenceDetector : IActionGenerator
 {
     private readonly ProjectsEnumerator enumerator;
 
+    public string[] CommandAliases => new[] { "check-package-reference", "cpa" };
+    public string CommandDescription => "Check for useless package references and try to remove them.";
+
     public UselessPackageReferenceDetector(ProjectsEnumerator enumerator)
     {
         this.enumerator = enumerator;
@@ -22,18 +25,6 @@ public class UselessPackageReferenceDetector : IActionGenerator
                 yield return reference;
             }
         }
-    }
-
-    public string GetCommandAlias()
-    {
-        // To do:
-        throw new NotImplementedException();
-    }
-
-    public string GetHelp()
-    {
-        // To do
-        throw new NotImplementedException();
     }
 
     private IEnumerable<UselessPackageReference> AnalyzeProject(Project context)

--- a/src/Generators/UselessProjectReferenceDetector.cs
+++ b/src/Generators/UselessProjectReferenceDetector.cs
@@ -7,6 +7,9 @@ public class UselessProjectReferenceDetector : IActionGenerator
 {
     private readonly ProjectsEnumerator enumerator;
 
+    public string[] CommandAliases => new[] { "check-project-reference", "cpj" };
+    public string CommandDescription => "Check for useless project references and try to remove them.";
+
     public UselessProjectReferenceDetector(ProjectsEnumerator enumerator)
     {
         this.enumerator = enumerator;

--- a/src/NugetNinja.csproj
+++ b/src/NugetNinja.csproj
@@ -13,5 +13,6 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -30,4 +30,4 @@ services.AddTransient<ProjectsEnumerator>();
 
 var serviceProvider = services.BuildServiceProvider();
 var entry = serviceProvider.GetRequiredService<Entry>();
-await entry.RunAsync(args);
+return await entry.RunAsync(args);


### PR DESCRIPTION
This pull request adds initial support of command-line interface.

```
$ .\NugetNinja.exe --help
Description:
  🥷 Nuget Ninja, a tool for detecting dependencies of .NET projects.

Usage:
  NugetNinja [command] [options]

Options:
  -d, --dry-run                 Preview changes without actually making them
  -p, --path <path> (REQUIRED)  Path of the project to be scanned
  --version                     Show version information
  -?, -h, --help                Show help and usage information

Commands:
  check-package-reference, cpa  Check for useless package references and try to remove them.
  check-project-reference, cpj  Check for useless project references and try to remove them.
```